### PR TITLE
Correct Dependencies - author for stdlib and concat

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -10,5 +10,5 @@ project_page 'http://www.thunderpoop.com'
 ## Add dependencies, if any:
 dependency 'panaman/hostint', '>= 2.0.2'
 dependency 'panaman/tps', '>= 1.0.2'
-dependency 'puppet/concat', '>=1.0.0'
-dependency 'puppet/stdlib', '>=4.1.0'
+dependency 'puppetlabs/concat', '>=1.0.0'
+dependency 'puppetlabs/stdlib', '>=4.1.0'

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'panaman-bro'
-version '1.0.0'
+version '1.0.1'
 source 'https://github.com/panaman/puppet-bro'
 author 'Panaman'
 license 'BSD'


### PR DESCRIPTION
Author `puppet` is not a valid author in Puppet Forge. This request corrects it to `puppetlabs`, and bumps the version up to `1.0.1`.
