### PR TITLE
ensure $network is an array

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,7 +18,7 @@ class bro::params {
   $pkg          = 'bro'
   $pkg_source   = 'repo'
   $type         = 'standalone'
-  $network      = $::hostint_ipv4_cidr 
+  $network      = any2array($::hostint_ipv4_cidr) 
   $etc_dir      = "$basedir/etc"
   $sitedir      = "$basedir/share/bro/site"
   $bro_pkg_name = $::osfamily ? {


### PR DESCRIPTION
The networks.cfg template expects the $network parameter to be an array. If applying a bare bro config (say only specify a monitor interface), it takes this parameter from hostint, but hostint defaults this value to the single network of the default route interface (presumably management interface).

any2array is found the latest puppetlabs/stdlib.
